### PR TITLE
Add pos check in parser if no null byte is found

### DIFF
--- a/src/main/java/devicetreeblob/parser/DtbBlock.java
+++ b/src/main/java/devicetreeblob/parser/DtbBlock.java
@@ -62,6 +62,8 @@ public class DtbBlock {
 			return;
 		for (DtbRegion r : regs) {
 			int pos = indexOf(regNames, 0);
+			if (pos == -1)
+				break;
 			r.name = new String(Arrays.copyOfRange(regNames, 0, pos), StandardCharsets.UTF_8);
 			regNames = Arrays.copyOfRange(regNames, pos+1, regNames.length);
 		}


### PR DESCRIPTION
I had a case with the DTB from RPi5 where no null byte was found, which ended up in a out of bounds exception

RPi5 firmware (with DTB): https://github.com/worproject/rpi5-uefi/releases/tag/v0.3

